### PR TITLE
Scryfall Card Data Processing

### DIFF
--- a/src/BargainMagic.Api.Service/Channels/CardFetcherChannel.cs
+++ b/src/BargainMagic.Api.Service/Channels/CardFetcherChannel.cs
@@ -1,0 +1,20 @@
+﻿using BargainMagic.Api.Service.Commands;
+
+using System.Threading.Channels;
+
+namespace BargainMagic.Api.Service.Channels
+{
+    public class CardFetcherChannel
+    {
+        private readonly Channel<CardFetchCommand> channel;
+
+        public CardFetcherChannel()
+        {
+            channel = Channel.CreateUnbounded<CardFetchCommand>();
+        }
+
+        public ChannelReader<CardFetchCommand> Reader => channel.Reader;
+
+        public ChannelWriter<CardFetchCommand> Writer => channel.Writer;
+    }
+}

--- a/src/BargainMagic.Api.Service/Commands/CardFetchCommand.cs
+++ b/src/BargainMagic.Api.Service/Commands/CardFetchCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace BargainMagic.Api.Service.Commands
+{
+    public class CardFetchCommand
+    {
+    }
+}

--- a/src/BargainMagic.Api.Service/Commands/CardFetchCommand.cs
+++ b/src/BargainMagic.Api.Service/Commands/CardFetchCommand.cs
@@ -2,5 +2,6 @@
 {
     public class CardFetchCommand
     {
+        public int SeasonId { get; set; }
     }
 }

--- a/src/BargainMagic.Api.Service/Controllers/SeasonController.cs
+++ b/src/BargainMagic.Api.Service/Controllers/SeasonController.cs
@@ -25,8 +25,22 @@ namespace BargainMagic.Api.Service.Controllers
                          {
                              Name = "TestSeason"
                          };
-
             dataContext.Seasons.Add(season);
+
+            var card = new Card
+                       {
+                           Name = "Omniscience"
+                       };
+            dataContext.Cards.Add(card);
+
+            var composite = new SeasonCardComposite
+                            {
+                                Season = season,
+                                Card = card,
+                                RawCost = 673
+                            };
+            dataContext.SeasonCardComposites.Add(composite);
+
             dataContext.SaveChanges();
 
             return Ok();

--- a/src/BargainMagic.Api.Service/Controllers/SeasonController.cs
+++ b/src/BargainMagic.Api.Service/Controllers/SeasonController.cs
@@ -1,9 +1,8 @@
 ﻿using BargainMagic.Api.Service.Channels;
 using BargainMagic.Api.Service.Commands;
-using BargainMagic.Api.Service.Entities;
+using BargainMagic.Api.Service.Repositories;
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace BargainMagic.Api.Service.Controllers
 {
@@ -11,30 +10,26 @@ namespace BargainMagic.Api.Service.Controllers
     [ApiController]
     public class SeasonController : ControllerBase
     {
-        private readonly IDbContextFactory<DataContext> dataContextFactory;
         private readonly CardFetcherChannel cardFetcherChannel;
+        private readonly SeasonRepository seasonRepository;
 
-        public SeasonController(IDbContextFactory<DataContext> dataContextFactory,
-                                CardFetcherChannel cardFetcherChannel)
+        public SeasonController(CardFetcherChannel cardFetcherChannel,
+                                SeasonRepository seasonRepository)
         {
-            this.dataContextFactory = dataContextFactory ?? throw new ArgumentNullException(nameof(dataContextFactory));
             this.cardFetcherChannel = cardFetcherChannel ?? throw new ArgumentNullException(nameof(cardFetcherChannel));
+            this.seasonRepository = seasonRepository ?? throw new ArgumentNullException(nameof(seasonRepository));
         }
 
         [HttpPost]
-        public ActionResult Create()
+        public async Task<ActionResult> Create(string seasonName)
         {
-            using var dataContext = dataContextFactory.CreateDbContext();
+            var seasonId = await seasonRepository.InsertSeason(seasonName);
 
-            var season = new Season
-                         {
-                             Name = "TestSeason"
-                         };
-            dataContext.Seasons.Add(season);
+            var cardFetchCommand = new CardFetchCommand
+                                   {
+                                       SeasonId = seasonId
+                                   };
 
-            dataContext.SaveChanges();
-
-            var cardFetchCommand = new CardFetchCommand();
             cardFetcherChannel.Writer.TryWrite(cardFetchCommand);
 
             return Ok();

--- a/src/BargainMagic.Api.Service/DataContext.cs
+++ b/src/BargainMagic.Api.Service/DataContext.cs
@@ -6,7 +6,9 @@ namespace BargainMagic.Api.Service
 {
     public class DataContext : DbContext
     {
+        public DbSet<Card> Cards { get; set; }
         public DbSet<Season> Seasons { get; set; }
+        public DbSet<SeasonCardComposite> SeasonCardComposites { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -23,7 +25,27 @@ namespace BargainMagic.Api.Service
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Season>().ToTable("Season");
+            modelBuilder.Entity<Card>()
+                        .ToTable("Card")
+                        .HasKey(e => e.Id);
+
+            modelBuilder.Entity<Season>()
+                        .ToTable("Season")
+                        .HasKey(e => e.Id);
+
+            modelBuilder.Entity<SeasonCardComposite>(entity =>
+            {
+                entity.ToTable("SeasonCardComposite");
+                entity.HasKey(e => new { e.SeasonId, e.CardId });
+
+                entity.HasOne(e => e.Season)
+                      .WithOne()
+                      .HasPrincipalKey<Season>(e => e.Id);
+
+                entity.HasOne(e => e.Card)
+                      .WithOne()
+                      .HasPrincipalKey<Card>(e => e.Id);
+            });
         }
     }
 }

--- a/src/BargainMagic.Api.Service/DataContext.cs
+++ b/src/BargainMagic.Api.Service/DataContext.cs
@@ -39,12 +39,12 @@ namespace BargainMagic.Api.Service
                 entity.HasKey(e => new { e.SeasonId, e.CardId });
 
                 entity.HasOne(e => e.Season)
-                      .WithOne()
-                      .HasPrincipalKey<Season>(e => e.Id);
+                      .WithMany()
+                      .HasForeignKey(e => e.SeasonId);
 
                 entity.HasOne(e => e.Card)
-                      .WithOne()
-                      .HasPrincipalKey<Card>(e => e.Id);
+                      .WithMany()
+                      .HasForeignKey(e => e.CardId);
             });
         }
     }

--- a/src/BargainMagic.Api.Service/Entities/Card.cs
+++ b/src/BargainMagic.Api.Service/Entities/Card.cs
@@ -1,14 +1,14 @@
 ﻿namespace BargainMagic.Api.Service.Entities
 {
-    public class Season
+    public class Card
     {
         /// <summary>
-        /// The unique identifier of the Season.
+        /// The unique identifier of the Card.
         /// </summary>
         public int Id { get; set; }
 
         /// <summary>
-        /// The human readible identifier of the Season.
+        /// The human readible identifier of the Card.
         /// </summary>
         public string? Name { get; set; }
     }

--- a/src/BargainMagic.Api.Service/Entities/SeasonCardComposite.cs
+++ b/src/BargainMagic.Api.Service/Entities/SeasonCardComposite.cs
@@ -1,0 +1,31 @@
+﻿namespace BargainMagic.Api.Service.Entities
+{
+    public class SeasonCardComposite
+    {
+        /// <summary>
+        /// The unique identifier of the Season.
+        /// </summary>
+        public int SeasonId { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the Card.
+        /// </summary>
+        public int CardId { get; set; }
+
+        /// <summary>
+        /// The "raw" cost value of the card. This is a whole number representation of the associated USD cost and will
+        /// need to be formatted for display purposes.
+        /// </summary>
+        public int RawCost { get; set; }
+
+        /// <summary>
+        /// The Season entity associated with the <see cref="SeasonId"/>.
+        /// </summary>
+        public Season? Season { get; set; }
+
+        /// <summary>
+        /// The Card entity associated with the <see cref="CardId"/>.
+        /// </summary>
+        public Card? Card { get; set; }
+    }
+}

--- a/src/BargainMagic.Api.Service/Models/BulkDataEndpointResponse.cs
+++ b/src/BargainMagic.Api.Service/Models/BulkDataEndpointResponse.cs
@@ -1,0 +1,40 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BargainMagic.Api.Service.Models
+{
+    public class BulkDataEndpointResponse
+    {
+        [JsonPropertyName("object")]
+        public string? Object { get; set; }
+
+        [JsonPropertyName("id")]
+        public Guid? Id { get; set; }
+
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime LastUpdated { get; set; }
+
+        [JsonPropertyName("uri")]
+        public string? Uri { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("size")]
+        public uint? Size { get; set; }
+
+        [JsonPropertyName("download_uri")]
+        public string? DownloadUri { get; set; }
+
+        [JsonPropertyName("content_type")]
+        public string? ContentType { get; set; }
+
+        [JsonPropertyName("content_encoding")]
+        public string? ContentEncoding { get; set; }
+    }
+}

--- a/src/BargainMagic.Api.Service/Models/ScryfallCardFaceModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallCardFaceModel.cs
@@ -1,0 +1,8 @@
+﻿namespace BargainMagic.Api.Service.Models
+{
+    public class ScryfallCardFaceModel
+    {
+        public string? Name { get; set; }
+        public string? TypeLine { get; set; }
+    }
+}

--- a/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
@@ -6,6 +6,7 @@
         public string? Layout { get; set; }
         public string? TypeLine { get; set; }
         public List<ScryfallCardFaceModel>? CardFaces { get; set; }
+        public Dictionary<string, string>? Legalities { get; set; }
         public ScryfallPricesModel? Prices { get; set; }
     }
 }

--- a/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
@@ -3,7 +3,9 @@
     public class ScryfallCardModel
     {
         public string? Name { get; set; }
+        public string? Layout { get; set; }
         public string? TypeLine { get; set; }
+        public List<ScryfallCardFaceModel>? CardFaces { get; set; }
         public ScryfallPricesModel? Prices { get; set; }
     }
 }

--- a/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BargainMagic.Api.Service.Models
+{
+    public class ScryfallCardModel
+    {
+        public string? Name { get; set; }
+        public ScryfallPricesModel? Prices { get; set; }
+    }
+}

--- a/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallCardModel.cs
@@ -1,10 +1,9 @@
-﻿using System.Text.Json.Serialization;
-
-namespace BargainMagic.Api.Service.Models
+﻿namespace BargainMagic.Api.Service.Models
 {
     public class ScryfallCardModel
     {
         public string? Name { get; set; }
+        public string? TypeLine { get; set; }
         public ScryfallPricesModel? Prices { get; set; }
     }
 }

--- a/src/BargainMagic.Api.Service/Models/ScryfallPricesModel.cs
+++ b/src/BargainMagic.Api.Service/Models/ScryfallPricesModel.cs
@@ -1,0 +1,9 @@
+﻿namespace BargainMagic.Api.Service.Models
+{
+    public class ScryfallPricesModel
+    {
+        public string? Usd { get; set; }
+        public string? UsdFoil { get; set; }
+        public string? UsdEtched { get; set; }
+    }
+}

--- a/src/BargainMagic.Api.Service/Program.cs
+++ b/src/BargainMagic.Api.Service/Program.cs
@@ -4,6 +4,8 @@ using BargainMagic.Api.Service.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.AddHttpClient();
+
 builder.Services.AddDbContextFactory<DataContext>();
 
 builder.Services.AddSingleton<CardFetcherChannel>();

--- a/src/BargainMagic.Api.Service/Program.cs
+++ b/src/BargainMagic.Api.Service/Program.cs
@@ -1,10 +1,17 @@
 using BargainMagic.Api.Service;
+using BargainMagic.Api.Service.Channels;
+using BargainMagic.Api.Service.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContextFactory<DataContext>();
 
+builder.Services.AddSingleton<CardFetcherChannel>();
+
+builder.Services.AddHostedService<CardFetcherService>();
+
 builder.Services.AddControllers();
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/BargainMagic.Api.Service/Program.cs
+++ b/src/BargainMagic.Api.Service/Program.cs
@@ -1,5 +1,6 @@
 using BargainMagic.Api.Service;
 using BargainMagic.Api.Service.Channels;
+using BargainMagic.Api.Service.Repositories;
 using BargainMagic.Api.Service.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +8,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
 
 builder.Services.AddDbContextFactory<DataContext>();
+
+builder.Services.AddSingleton<CardRepository>();
+
+builder.Services.AddSingleton<CardFetcherChannel>();
 
 builder.Services.AddSingleton<CardFetcherChannel>();
 

--- a/src/BargainMagic.Api.Service/Program.cs
+++ b/src/BargainMagic.Api.Service/Program.cs
@@ -10,6 +10,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddDbContextFactory<DataContext>();
 
 builder.Services.AddSingleton<CardRepository>();
+builder.Services.AddSingleton<SeasonRepository>();
 
 builder.Services.AddSingleton<CardFetcherChannel>();
 

--- a/src/BargainMagic.Api.Service/Repositories/CardRepository.cs
+++ b/src/BargainMagic.Api.Service/Repositories/CardRepository.cs
@@ -34,5 +34,31 @@ namespace BargainMagic.Api.Service.Repositories
 
             return card.Id;
         }
+    
+        public async Task InsertSeasonCardCompositeAsync(int seasonId,
+                                                         int cardId,
+                                                         int rawCost)
+        {
+            using var dataContext = dataContextFactory.CreateDbContext();
+
+            var seasonCardComposite = dataContext.SeasonCardComposites.FirstOrDefault(scc => scc.SeasonId == seasonId
+                                                                                          && scc.CardId == cardId);
+
+            if (seasonCardComposite != null)
+            {
+                return;
+            }
+
+            seasonCardComposite = new SeasonCardComposite
+                                  {
+                                      SeasonId = seasonId,
+                                      CardId = cardId,
+                                      RawCost = rawCost
+                                  };
+
+            dataContext.SeasonCardComposites.Add(seasonCardComposite);
+
+            await dataContext.SaveChangesAsync();
+        }
     }
 }

--- a/src/BargainMagic.Api.Service/Repositories/CardRepository.cs
+++ b/src/BargainMagic.Api.Service/Repositories/CardRepository.cs
@@ -1,0 +1,38 @@
+﻿using BargainMagic.Api.Service.Entities;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace BargainMagic.Api.Service.Repositories
+{
+    public class CardRepository
+    {
+        private readonly IDbContextFactory<DataContext> dataContextFactory;
+
+        public CardRepository(IDbContextFactory<DataContext> dataContextFactory)
+        {
+            this.dataContextFactory = dataContextFactory ?? throw new ArgumentNullException(nameof(dataContextFactory));
+        }
+
+        public async Task<int> InsertCardAsync(string cardName)
+        {
+            using var dataContext = dataContextFactory.CreateDbContext();
+
+            // Check to see if the card 
+            var card = dataContext.Cards.FirstOrDefault(c => c.Name == cardName);
+
+            if (card == null)
+            {
+                card = new Card
+                {
+                    Name = cardName
+                };
+
+                dataContext.Cards.Add(card);
+            }
+
+            await dataContext.SaveChangesAsync();
+
+            return card.Id;
+        }
+    }
+}

--- a/src/BargainMagic.Api.Service/Repositories/SeasonRepository.cs
+++ b/src/BargainMagic.Api.Service/Repositories/SeasonRepository.cs
@@ -1,0 +1,47 @@
+﻿using BargainMagic.Api.Service.Entities;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace BargainMagic.Api.Service.Repositories
+{
+    public class SeasonRepository
+    {
+        private readonly IDbContextFactory<DataContext> dataContextFactory;
+
+        public SeasonRepository(IDbContextFactory<DataContext> dataContextFactory)
+        {
+            this.dataContextFactory = dataContextFactory ?? throw new ArgumentNullException(nameof(dataContextFactory));
+        }
+
+        public async Task<Season?> GetSeason(int seasonId)
+        {
+            using var dataContext = dataContextFactory.CreateDbContext();
+
+            return await dataContext.Seasons.FirstOrDefaultAsync(s => s.Id == seasonId);
+        }
+
+        public async Task<int> InsertSeason(string seasonName)
+        {
+            using var dataContext = dataContextFactory.CreateDbContext();
+
+            var season = dataContext.Seasons.FirstOrDefault(s => s.Name == seasonName);
+
+            if (season != null)
+            {
+                return default;
+            }
+
+            season = new Season
+                     {
+                         Name = seasonName
+                     };
+
+            dataContext.Seasons.Add(season);
+
+            await dataContext.SaveChangesAsync();
+
+            return season.Id;
+
+        }
+    }
+}

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -60,6 +60,7 @@ namespace BargainMagic.Api.Service.Services
                     continue;
                 }
 
+                const string NotLegal = "not_legal";
                 const string ReversableCardLayout = "reversible_card";
                 const string TypeLineRegex = "Token|Basic";
 
@@ -85,6 +86,12 @@ namespace BargainMagic.Api.Service.Services
 
                     if (cardModel.TypeLine == null ||
                         Regex.Match(cardModel.TypeLine, TypeLineRegex).Success)
+                    {
+                        continue;
+                    }
+
+                    if (cardModel.Legalities == null ||
+                        cardModel.Legalities.All(l => l.Value == NotLegal))
                     {
                         continue;
                     }

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -1,0 +1,29 @@
+﻿using BargainMagic.Api.Service.Channels;
+
+namespace BargainMagic.Api.Service.Services
+{
+    public class CardFetcherService : BackgroundService
+    {
+        private readonly CardFetcherChannel cardFetcherChannel;
+
+        public CardFetcherService(CardFetcherChannel cardFetchChannel)
+        {
+            this.cardFetcherChannel = cardFetchChannel ?? throw new ArgumentNullException(nameof(cardFetchChannel));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await cardFetcherChannel.Reader.WaitToReadAsync(cancellationToken);
+
+                if (!cardFetcherChannel.Reader.TryRead(out var cardFetchCommmand))
+                {
+                    continue;
+                }
+
+                Console.WriteLine(cardFetchCommmand.ToString());
+            }
+        }
+    }
+}

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -51,7 +51,6 @@ namespace BargainMagic.Api.Service.Services
                     PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
                 };
 
-
                 var deserializedCardModels =
                     JsonSerializer.Deserialize<List<ScryfallCardModel>>(json: cardDataJsonString,
                                                                         options: serializerOptions);
@@ -61,12 +60,29 @@ namespace BargainMagic.Api.Service.Services
                     continue;
                 }
 
+                const string ReversableCardLayout = "reversible_card";
                 const string TypeLineRegex = "Token|Basic";
 
                 var filteredCardModels = new List<ScryfallCardModel>();
                 
                 foreach (var cardModel in deserializedCardModels)
                 {
+                    if (cardModel.Layout == ReversableCardLayout &&
+                        cardModel.CardFaces != null)
+                    {
+                        var frontCardFace = cardModel.CardFaces.FirstOrDefault();
+
+                        if (frontCardFace != null)
+                        {
+                            cardModel.Name = frontCardFace.Name;
+                            cardModel.TypeLine = frontCardFace.TypeLine;
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+
                     if (cardModel.TypeLine == null ||
                         Regex.Match(cardModel.TypeLine, TypeLineRegex).Success)
                     {

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -99,11 +99,6 @@ namespace BargainMagic.Api.Service.Services
                     filteredCardModels.Add(cardModel);
                 }
 
-                /*
-                var filteredCardModels =
-                    deserializedCardModels.Where(c => c.TypeLine == null ||
-                                                 !Regex.Match(c.TypeLine, TypeLineRegex).Success);
-                */
                 var groupedCardModels =
                     filteredCardModels.GroupBy(c => c.Name,
                                                c => c.Prices,

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -121,20 +121,9 @@ namespace BargainMagic.Api.Service.Services
 
                     var rawMinimumPrice = priceList.Min() * 100;
 
-                    Console.WriteLine($"Adding Card [{cardModelGroup.Name} : {cardId}] with price [{rawMinimumPrice}]");
-                    /*
-                    var seasonCardComposite = new SeasonCardComposite
-                                              {
-                                                  Season = season,
-                                                  SeasonId = season.Id,
-                                                  Card = card,
-                                                  CardId = card.Id,
-                                                  RawCost = (int)rawMinimumPrice
-                                              };
-                    dataContext.SeasonCardComposites.Add(seasonCardComposite);
-                    
-                    await dataContext.SaveChangesAsync();
-                    */
+                    await cardRepository.InsertSeasonCardCompositeAsync(seasonId: season.Id,
+                                                                        cardId: cardId,
+                                                                        rawCost: (int)rawMinimumPrice);
                 }
             }
         }

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -18,14 +18,17 @@ namespace BargainMagic.Api.Service.Services
         private readonly CardFetcherChannel cardFetcherChannel;
         private readonly CardRepository cardRepository;
         private readonly IHttpClientFactory httpClientFactory;
+        private readonly SeasonRepository seasonRepository;
 
         public CardFetcherService(CardFetcherChannel cardFetchChannel,
                                   CardRepository cardRepository,
-                                  IHttpClientFactory httpClientFactory)
+                                  IHttpClientFactory httpClientFactory,
+                                  SeasonRepository seasonRepository)
         {
             this.cardFetcherChannel = cardFetchChannel ?? throw new ArgumentNullException(nameof(cardFetchChannel));
             this.cardRepository = cardRepository ?? throw new ArgumentNullException(nameof(cardRepository));
             this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            this.seasonRepository = seasonRepository ?? throw new ArgumentNullException(nameof(seasonRepository));
         }
 
         protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -65,6 +68,13 @@ namespace BargainMagic.Api.Service.Services
                                                        PriceModels = prices.ToList()
                                                    })
                                           .ToList();
+
+                var season = await seasonRepository.GetSeason(cardFetchCommmand.SeasonId);
+
+                if (season == null)
+                {
+                    continue;
+                }
 
                 foreach (var cardModelGroup in groupedCardModels)
                 {

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -1,7 +1,7 @@
 ﻿using BargainMagic.Api.Service.Channels;
 using BargainMagic.Api.Service.Models;
+using BargainMagic.Api.Service.Repositories;
 
-using System.Net.Http;
 using System.Text.Json;
 
 namespace BargainMagic.Api.Service.Services
@@ -16,12 +16,15 @@ namespace BargainMagic.Api.Service.Services
         #endregion Constants
 
         private readonly CardFetcherChannel cardFetcherChannel;
+        private readonly CardRepository cardRepository;
         private readonly IHttpClientFactory httpClientFactory;
 
         public CardFetcherService(CardFetcherChannel cardFetchChannel,
+                                  CardRepository cardRepository,
                                   IHttpClientFactory httpClientFactory)
         {
             this.cardFetcherChannel = cardFetchChannel ?? throw new ArgumentNullException(nameof(cardFetchChannel));
+            this.cardRepository = cardRepository ?? throw new ArgumentNullException(nameof(cardRepository));
             this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         }
 
@@ -37,6 +40,92 @@ namespace BargainMagic.Api.Service.Services
                 }
 
                 var cardDataJsonString = await GetCardDataAsync();
+
+                var serializerOptions = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = false,
+                    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+                };
+
+                var deserializedCardModels =
+                    JsonSerializer.Deserialize<List<ScryfallCardModel>>(json: cardDataJsonString,
+                                                                        options: serializerOptions);
+
+                if (deserializedCardModels == null)
+                {
+                    continue;
+                }
+
+                var groupedCardModels =
+                    deserializedCardModels.GroupBy(c => c.Name,
+                                                   c => c.Prices,
+                                                   (name, prices) => new
+                                                   {
+                                                       Name = name,
+                                                       PriceModels = prices.ToList()
+                                                   })
+                                          .ToList();
+
+                foreach (var cardModelGroup in groupedCardModels)
+                {
+                    if (cardModelGroup.Name == default ||
+                        cardModelGroup.PriceModels == null ||
+                        cardModelGroup.PriceModels.Count <= 0)
+                    {
+                        continue;
+                    }
+
+                    var cardId = await cardRepository.InsertCardAsync(cardModelGroup.Name);
+                    
+                    var priceList = new List<decimal>();
+
+                    void AddPrice(string? priceString)
+                    {
+                        if (priceString == null)
+                        {
+                            return;
+                        }
+
+                        decimal.TryParse(priceString,
+                                         out var decimalPrice);
+
+                        priceList.Add(decimalPrice);
+                    }
+
+                    foreach (var priceModel in cardModelGroup.PriceModels)
+                    {
+                        if (priceModel == null)
+                        {
+                            continue;
+                        }
+
+                        AddPrice(priceModel.Usd);
+                        AddPrice(priceModel.UsdFoil);
+                        AddPrice(priceModel.UsdEtched);
+                    }
+
+                    if (priceList.Count <= 0)
+                    {
+                        continue;
+                    }
+
+                    var rawMinimumPrice = priceList.Min() * 100;
+
+                    Console.WriteLine($"Adding Card [{cardModelGroup.Name} : {cardId}] with price [{rawMinimumPrice}]");
+                    /*
+                    var seasonCardComposite = new SeasonCardComposite
+                                              {
+                                                  Season = season,
+                                                  SeasonId = season.Id,
+                                                  Card = card,
+                                                  CardId = card.Id,
+                                                  RawCost = (int)rawMinimumPrice
+                                              };
+                    dataContext.SeasonCardComposites.Add(seasonCardComposite);
+                    
+                    await dataContext.SaveChangesAsync();
+                    */
+                }
             }
         }
 

--- a/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
+++ b/src/BargainMagic.Api.Service/Services/CardFetcherService.cs
@@ -1,14 +1,28 @@
 ﻿using BargainMagic.Api.Service.Channels;
+using BargainMagic.Api.Service.Models;
+
+using System.Net.Http;
+using System.Text.Json;
 
 namespace BargainMagic.Api.Service.Services
 {
     public class CardFetcherService : BackgroundService
     {
-        private readonly CardFetcherChannel cardFetcherChannel;
+        #region Constants
 
-        public CardFetcherService(CardFetcherChannel cardFetchChannel)
+        protected const string DefaultCardsEndpointInformationUri = "https://api.scryfall.com/bulk-data/default-cards";
+        protected const string HttpClientName = "Scryfall";
+
+        #endregion Constants
+
+        private readonly CardFetcherChannel cardFetcherChannel;
+        private readonly IHttpClientFactory httpClientFactory;
+
+        public CardFetcherService(CardFetcherChannel cardFetchChannel,
+                                  IHttpClientFactory httpClientFactory)
         {
             this.cardFetcherChannel = cardFetchChannel ?? throw new ArgumentNullException(nameof(cardFetchChannel));
+            this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         }
 
         protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -22,8 +36,43 @@ namespace BargainMagic.Api.Service.Services
                     continue;
                 }
 
-                Console.WriteLine(cardFetchCommmand.ToString());
+                var cardDataJsonString = await GetCardDataAsync();
             }
+        }
+
+        public async Task<string> GetCardDataAsync()
+        {
+            using var httpClient = this.httpClientFactory.CreateClient(HttpClientName);
+            
+            var endpointInformation = await this.GetDefaultCardEndpointInformationAsync(httpClient);
+
+            if (endpointInformation == null)
+            {
+                throw new Exception("Failed retrieving endpoint information from Scryfall.");
+            }
+
+            if (string.IsNullOrWhiteSpace(endpointInformation.DownloadUri))
+            {
+                throw new Exception("Retrieved Skryfall endpoint information did not contain a download URI.");
+            }
+
+            return await httpClient.GetStringAsync(endpointInformation.DownloadUri);
+        }
+
+        private async Task<BulkDataEndpointResponse?> GetDefaultCardEndpointInformationAsync(HttpClient httpClient)
+        {
+            var endpointInformationString = await httpClient.GetStringAsync(DefaultCardsEndpointInformationUri);
+
+            try
+            {
+                return JsonSerializer.Deserialize<BulkDataEndpointResponse>(endpointInformationString);
+            }
+            catch (Exception)
+            {
+                // TODO: Add logging here.
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Implementing Season creation mechanics by downloading bulk card data from Scryfall and parsing it into the data layer. Current filters being applied to the data are:
Excludes Basic Lands
Excludes Tokens
Excludes any card not legal in any format (Un-Set cards, Art cards, etc.)

A work around had to be made for certain dual faced Secret Lair drops since the type_line property was not available in the same location. In these cases we are pulling the first face of the card and overriding the card models name and type line with those values. This ensures those printings are grouped correctly for evaluation of the minimum price. 